### PR TITLE
Downgrade express-jwt to 5.3.3

### DIFF
--- a/api_service/package.json
+++ b/api_service/package.json
@@ -21,7 +21,7 @@
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "express-jwt": "^6.0.0",
+    "express-jwt": "^5.3.3",
     "express-validator": "^6.5.0",
     "iso-639-1": "^2.1.1",
     "mongodb": "^3.5.7"


### PR DESCRIPTION
Version 6.0.0 breaks the compatibility.